### PR TITLE
fix default badge file name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -27,11 +27,12 @@ function istanbulCoberturaBadger(opts, callback) {
     shieldsHost: process.env.SHIELDS_HOST || "https://img.shields.io",
     // The style of shield icon to generate (plastic, flat-square, flat)
     shieldStyle: "flat",
-    // The name of the badge file to be generated
-    badgeFileName: "coverage",
     // The thresholds to be used to give colors to the badge.
     thresholds: defaultThresholds
   }, opts);
+
+  // The name of the badge file to be generated
+  opts.badgeFileName = opts.badgeFileName || "coverage";
 
   reportParser(opts.istanbulReportFile, function(err, report) {
     if (err) {


### PR DESCRIPTION
badge file name remains `undefined` if it's not passed as an option, so let's explicitly check if it's undefined and set it to `coverage.svg` if it's not
