### PR TITLE
add support for specifying badge format

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -14,6 +14,7 @@ var defaultThresholds = require("./defaultThresholds");
 
 program.description("Generates a badge for a given Cobertura XML report")
   .version(pkgJson.version)
+  .option("-F, --format <type>", "Format of the generated badge. (SVG by default)", "svg")
   .option("-f, --defaults", "Use the default values for all the input.")
   .option("-e, --excellentThreashold <n>", "The threshold for green badges, where coverage >= -e", parseInt)
   .option("-g, --goodThreashold <n>", "The threshold for yellow badges, where -g <= coverage < -e  ", parseInt)
@@ -48,6 +49,7 @@ if (!program.defaults && !process.argv.slice(2).length) {
 // The options to the badger API coming from the program.
 var opts = {
   badgeFileName: program.badgeFileName,
+  badgeFormat: program.format,
   destinationDir: path.resolve(program.destinationDir),
   istanbulReportFile: program.reportFile,
   thresholds: {

--- a/lib/index.js
+++ b/lib/index.js
@@ -33,6 +33,8 @@ function istanbulCoberturaBadger(opts, callback) {
     thresholds: defaultThresholds
   }, opts);
 
+  opts.badgeFormat = opts.badgeFormat || "svg";
+
   reportParser(opts.istanbulReportFile, function(err, report) {
     if (err) {
       return callback(err);
@@ -44,10 +46,10 @@ function istanbulCoberturaBadger(opts, callback) {
 
     // The shields service that will give badges.
     var url = opts.shieldsHost + "/badge/coverage-" + report.overallPercent;
-    url += "%-" + color + ".svg?style=" + opts.shieldStyle;
+    url += "%-" + color + "." + opts.badgeFormat + "?style=" + opts.shieldStyle;
 
     // Save always as coverage image.
-    var badgeFileName = path.join(opts.destinationDir, opts.badgeFileName + ".svg");
+    var badgeFileName = path.join(opts.destinationDir, opts.badgeFileName + "." + opts.badgeFormat);
 
     downloader(url, badgeFileName, function(err, downloadResult) {
       if (err) {


### PR DESCRIPTION
still uses `svg` by default and adds support for multiple badge formats. I have to use `png` since I want to show this badge in the README of a Github repo. Github blacklists linking to `svg` files due to security concerns so I have to use some other image format.
