### PR TITLE
URL encode percent sign

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,7 @@ function istanbulCoberturaBadger(opts, callback) {
 
     // The shields service that will give badges.
     var url = opts.shieldsHost + "/badge/coverage-" + report.overallPercent;
-    url += "%-" + color + "." + opts.badgeFormat + "?style=" + opts.shieldStyle;
+    url += "%25-" + color + "." + opts.badgeFormat + "?style=" + opts.shieldStyle;
 
     // Save always as coverage image.
     var badgeFileName = path.join(opts.destinationDir, opts.badgeFileName + "." + opts.badgeFormat);


### PR DESCRIPTION
Fixes 400 Bad Request error with CloudFlare when requesting badge from shields.io by URL encoding the percent sign as `%25`.

**SVG Badge Content Before Change**
>`https://imsg.shields.io/badge/coverage-100%-blue.svg`
```
<html>
<head><title>400 Bad Request</title></head>
<body bgcolor="white">
<center><h1>400 Bad Request</h1></center>
<hr><center>cloudflare-nginx</center>
</body>
</html>
```

**SVG Badge Content After Change**
>`https://imsg.shields.io/badge/coverage-100%25-blue.svg`
```
<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="102" height="20"><linearGradient id="b" x2="0" y2="100%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient><clipPath id="a"><rect width="102" height="20" rx="3" fill="#fff"/></clipPath><g clip-path="url(#a)"><path fill="#555" d="M0 0h59v20H0z"/><path fill="#4c1" d="M59 0h43v20H59z"/><path fill="url(#b)" d="M0 0h102v20H0z"/></g><g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="11"><text x="29.5" y="15" fill="#010101" fill-opacity=".3">coverage</text><text x="29.5" y="14">coverage</text><text x="79.5" y="15" fill="#010101" fill-opacity=".3">100%</text><text x="79.5" y="14">100%</text></g></svg>
```