### PR TITLE
Fix for: Cannot read property 'classes' of undefined

### DIFF
--- a/lib/coberturaReportParser.js
+++ b/lib/coberturaReportParser.js
@@ -37,7 +37,7 @@ function processPackage(packageObject, computation) {
     packageObject.classes.class.forEach(function(clazz) {
       processClass(clazz, computation);
     });
-  } else if (packageObject.classes.class) {
+  } else if (packageObject.classes && packageObject.classes.class) {
     // Single class to be processed
     processClass(packageObject.classes.class, computation);
   } else if (packageObject.class && packageObject.class instanceof Array) {

--- a/lib/coberturaReportParser.js
+++ b/lib/coberturaReportParser.js
@@ -16,9 +16,10 @@ function processReport(xml, computation) {
     xml.packages.package.forEach(function(packageObject) {
       processPackage(packageObject, computation);
     });
-
-  } else {
+  } else if (xml.packages.package) {
     processPackage(xml.packages.package, computation);
+  } else {
+    processPackage(xml.packages, computation);
   }
 }
 
@@ -31,15 +32,20 @@ function processReport(xml, computation) {
  * @param {Object} computation is the result of the computation.
  */
 function processPackage(packageObject, computation) {
-  if (packageObject.classes.class instanceof Array) {
+  if (packageObject.classes && packageObject.classes.class instanceof Array) {
     // Process each individual class
     packageObject.classes.class.forEach(function(clazz) {
       processClass(clazz, computation);
     });
-
-  } else {
+  } else if (packageObject.classes.class) {
     // Single class to be processed
     processClass(packageObject.classes.class, computation);
+  } else if (packageObject.class && packageObject.class instanceof Array) {
+    packageObject.class.forEach(function(clazz) {
+      processClass(clazz, computation);
+    });
+  } else {
+    processClass(packageObject.class, computation);
   }
 }
 

--- a/test/fixture/istanbul-report-multiple-packages-without-classes.xml
+++ b/test/fixture/istanbul-report-multiple-packages-without-classes.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" ?>
+<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
+<coverage lines-valid="328"  lines-covered="255"  line-rate="0.7774"  branches-valid="58"  branches-covered="30"  branch-rate="0.5172"  timestamp="1444266082605" complexity="0" version="0.1">
+<sources>
+	<source>/home/mdesales/dev/github-intuit/servicesplatform-nodejs/sp-quality</source>
+</sources>
+<packages>
+  <class name="lint.js"  filename="lint.js"  line-rate="1"  branch-rate="1" >
+		<methods>
+		</methods>
+		<lines>
+			<line number="5"  hits="1"  branch="false" />
+			<line number="10"  hits="1"  branch="false" />
+		</lines>
+  </class>
+  <class name="test.js"  filename="test.js"  line-rate="0.6"  branch-rate="1" >
+		<methods>
+			<method name="(anonymous_1)"  hits="0"  signature="()V" >
+				<lines><line number="8"  hits="0" /></lines>
+			</method>
+			<method name="(anonymous_2)"  hits="8"  signature="()V" >
+				<lines><line number="15"  hits="8" /></lines>
+			</method>
+			<method name="(anonymous_3)"  hits="0"  signature="()V" >
+				<lines><line number="22"  hits="0" /></lines>
+			</method>
+			<method name="(anonymous_4)"  hits="0"  signature="()V" >
+				<lines><line number="29"  hits="0" /></lines>
+			</method>
+			<method name="(anonymous_5)"  hits="0"  signature="()V" >
+				<lines><line number="37"  hits="0" /></lines>
+			</method>
+		</methods>
+		<lines>
+			<line number="8"  hits="1"  branch="false" />
+			<line number="9"  hits="0"  branch="false" />
+			<line number="15"  hits="1"  branch="false" />
+			<line number="16"  hits="8"  branch="false" />
+			<line number="22"  hits="1"  branch="false" />
+			<line number="23"  hits="0"  branch="false" />
+			<line number="29"  hits="1"  branch="false" />
+			<line number="30"  hits="0"  branch="false" />
+			<line number="37"  hits="1"  branch="false" />
+			<line number="38"  hits="0"  branch="false" />
+		</lines>
+  </class>
+</packages>
+</coverage>

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -94,6 +94,47 @@ describe("istanbul-cobertura-badger", function() {
       });
     });
 
+    it("should compute overall coverage over packages without classes and create the badge", function(done) {
+      // Use the fixture that's without problems
+      // Using defaults directory /coverage/
+      var opts = {
+        badgeFileName: "coverage-multiple-without-classes",
+        destinationDir: destinationDir,
+        istanbulReportFile: path.resolve(__dirname, "fixture", "istanbul-report-multiple-packages-without-classes.xml")
+      };
+
+      // Load the badge for the report
+      badger(opts, function parsingResults(err, badgeStatus) {
+        expect(err).to.be.null;
+        expect(badgeStatus).to.be.an("object");
+
+        console.log(badgeStatus);
+
+        var fileWithExtension = opts.badgeFileName + ".svg";
+        var coverageBadgePath = path.normalize(path.resolve(destinationDir, fileWithExtension));
+        expect(coverageBadgePath.indexOf(fileWithExtension)).to.be.above(0);
+
+        // Verify that the badge file was successfully created
+        fs.stat(coverageBadgePath, function gettingStats(err, stats) {
+          expect(err).to.be.null;
+          expect(stats).to.be.an("object");
+          expect(stats.isFile()).to.be.true;
+          expect(stats.size).to.be.above(0);
+
+          fs.unlink(coverageBadgePath, function(err) {
+            if (err) {
+              console.log(err);
+            }
+            console.log("Deleted the badge file " + coverageBadgePath);
+
+            done();
+          });
+
+        });
+
+      });
+    });
+
   });
 
   describe("Parsing reports with xml problems", function() {


### PR DESCRIPTION
This fix allow to handle different xml structures
In my case, the cobertura-coverage.xml had a different structure that made the lib crash:
```
<?xml version="1.0" ?>
<!DOCTYPE coverage SYSTEM "http://cobertura.sourceforge.net/xml/coverage-04.dtd">
<coverage lines-valid="33" lines-covered="29" line-rate="0.8787999999999999" branches-valid="10" branches-covered="8" branch-rate="0.8" timestamp="1523546158798" complexity="0" version="0.1">
  <sources>
    <source>/Users/xxx/xxx/app</source>
  </sources>
  <packages>
    <class name="app.js" filename="dist/app.js" line-rate="0.9" branch-rate="0.8">
    ...
    </class>
  </packages>
```

Using 
"istanbul": "v1.1.0-alpha.1"
"remap-istanbul": "^0.9.5"
"mocha": "^3.5.3"